### PR TITLE
エッジとノードをフォーカスする仕組みを実装

### DIFF
--- a/src/components/Line.tsx
+++ b/src/components/Line.tsx
@@ -1,22 +1,31 @@
 import React from "react"
-import { Edge, GraphNode } from "./editor/node"
+import { GraphNode } from "./editor/node"
 import { getPointPos } from "./editor/helper"
 import LineUI from "./presentation/LineUI"
 
 export type LineProps = {
-  edge: Edge
-  getNode: (nodeId: string) => GraphNode | null
+  start: {
+    node: GraphNode
+    pointId: number
+  }
+  end: {
+    node: GraphNode
+    pointId: number
+  }
+  isFocused: boolean
+  onFocus: () => void
   onDelete: () => void
 }
 
-const Line: React.FC<LineProps> = ({ edge, getNode, onDelete }) => {
-  const startNode = getNode(edge.start.nodeId)
-  const endNode = getNode(edge.end.nodeId)
-  if (startNode == null || endNode == null) {
-    return null
-  }
-  const startPointPos = getPointPos("out", startNode, edge.start.pointId)
-  const endPointPos = getPointPos("in", endNode, edge.end.pointId)
+const Line: React.FC<LineProps> = ({
+  start,
+  end,
+  isFocused,
+  onFocus,
+  onDelete,
+}) => {
+  const startPointPos = getPointPos("out", start.node, start.pointId)
+  const endPointPos = getPointPos("in", end.node, end.pointId)
   const deltaX = endPointPos.x - startPointPos.x
   const deltaY = endPointPos.y - startPointPos.y
   return (
@@ -24,6 +33,8 @@ const Line: React.FC<LineProps> = ({ edge, getNode, onDelete }) => {
       <LineUI
         startPos={startPointPos}
         delta={{ x: deltaX, y: deltaY }}
+        isFocused={isFocused}
+        onFocus={onFocus}
         onDelete={onDelete}
       />
     </div>

--- a/src/components/componetsSideList.tsx
+++ b/src/components/componetsSideList.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames"
-import { useCallback, useState } from "react"
+import { useCallback, useId, useMemo, useState } from "react"
 import Draggable from "react-draggable"
-import { getPointPos, isSameEdge } from "./editor/helper"
+import { calcEdgeId, getPointPos, isSameEdge } from "./editor/helper"
 import { Coordinate, Edge, GraphNodeClass } from "./editor/node"
 import useCursorPos from "./utils/getCursorPos"
 import Line from "./Line"
@@ -106,7 +106,9 @@ const INIT_NODES = [
         x: 50,
         y: 50,
       },
-      inPoints: [{ type: "number", label: "input", limit: null }],
+      inPoints: [
+        // { type: "number", label: "input", limit: null }
+      ],
       outPoints: [{ type: "number", label: "confirmed", limit: null }],
     },
   ),
@@ -159,8 +161,8 @@ const INIT_NODES = [
       },
       inPoints: [{ type: "number", label: "input", limit: null }],
       outPoints: [
-        { type: "number", label: "yes", limit: null },
-        { type: "number", label: "no", limit: null },
+        // { type: "number", label: "yes", limit: null },
+        // { type: "number", label: "no", limit: null },
       ],
     },
   ),
@@ -191,10 +193,45 @@ const fixedInitNodePosList: Coordinate[] = INIT_NODES.map(
   (node: GraphNodeClass) => node.pos,
 )
 
-const ComponentsSideList = () => {
+const checkNodeType = (node: GraphNodeClass) => {
+  if (node.node.nodeType == "textInputNode") {
+    return <TextInputNode />
+  } else if (node.node.nodeType == "includeCheckNode") {
+    return <IncludeCheckNode node={node} />
+  } else if (node.node.nodeType == "correspondCheckNode") {
+    return <CorrespondCheckNode node={node} />
+  } else if (node.node.nodeType == "textOutputNode") {
+    return <TextOutputNode node={node} />
+  } else if (node.node.nodeType == "weatherCheckNode") {
+    return <WeatherCheckNode />
+  } else {
+    return node.node.label
+  }
+}
+
+const ComponentsSideList: React.FC = () => {
   //nodeとedgeの状態管理　えｄげは線
   const [nodes, setNodes] = useState<GraphNodeClass[]>(INIT_NODES)
   const [edges, setEdges] = useState<Edge[]>([])
+
+  const [focusItemId, setFocusItemId] = useState<
+    | { type: "node"; nodeId: string }
+    | {
+        type: "edge"
+        start: {
+          nodeId: string
+          pointId: number
+        }
+        end: {
+          nodeId: string
+          pointId: number
+        }
+      }
+    | null
+  >({
+    type: "node",
+    nodeId: INIT_NODES[0].id,
+  })
 
   //初期のnodeがドラッグされると初期位置に新たなnodeを追加する
   //ドラッグされたnodeを受け取り，それが初期位置にあったnodeなら初期位置に同じnodeを追加
@@ -218,32 +255,6 @@ const ComponentsSideList = () => {
     }
   }
 
-  const checkNodeType = (node: GraphNodeClass) => {
-    if (node.node.nodeType == "textInputNode") {
-      return <TextInputNode />
-    } else if (node.node.nodeType == "includeCheckNode") {
-      return <IncludeCheckNode node={node} />
-    } else if (node.node.nodeType == "correspondCheckNode") {
-      return <CorrespondCheckNode node={node} />
-    } else if (node.node.nodeType == "textOutputNode") {
-      return <TextOutputNode node={node} />
-    } else if (node.node.nodeType == "weatherCheckNode") {
-      return <WeatherCheckNode />
-    } else {
-      return node.node.label
-    }
-  }
-
-  //一時的に触っているnode
-  const [tmpEdgeStartNodeId, setTempEdgeStartNodeId] = useState<{
-    nodeId: string
-    pointId: number
-    //|はnull許容用
-  } | null>(null)
-
-  //カーソルのpositionをチェック
-  const cursorPos = useCursorPos(tmpEdgeStartNodeId != null)
-
   //getNodeに関数を代入しているだけ
   const getNode = useCallback(
     (nodeId: string) => {
@@ -253,16 +264,50 @@ const ComponentsSideList = () => {
     [nodes],
   )
 
+  //一時的に触っているnodeのidとpointのid
+  const [tmpEdgeStartNodeId, setTempEdgeStartNodeId] = useState<{
+    nodeId: string
+    pointId: number
+    //|はnull許容用
+  } | null>(null)
+
+  // 一時的に触っているnodeとpoint id
+  const tmpEdgeStartNode = useMemo(() => {
+    if (tmpEdgeStartNodeId == null) {
+      return null
+    }
+    const tmpNode = getNode(tmpEdgeStartNodeId.nodeId)
+    if (tmpNode == null) {
+      return null
+    }
+    return {
+      node: tmpNode,
+      pointId: tmpEdgeStartNodeId.pointId,
+    }
+  }, [getNode, tmpEdgeStartNodeId])
+
+  //カーソルのpositionをチェック
+  const cursorPos = useCursorPos(tmpEdgeStartNodeId != null)
+
+  const rootId = useId()
+
   return (
     //枠線の指定
     <div
+      id={rootId}
       className="draggable-parent static min-h-screen border border-blue-100"
-      onClick={() => setTempEdgeStartNodeId(null)}
+      onClick={(e) => {
+        // @ts-ignore
+        if (e.target.id === rootId) {
+          setFocusItemId(null)
+        }
+        setTempEdgeStartNodeId(null)
+      }}
     >
       {/* 線? */}
-      {tmpEdgeStartNodeId != null &&
+      {tmpEdgeStartNode != null &&
         (() => {
-          const tmpStartNode = getNode(tmpEdgeStartNodeId.nodeId)
+          const tmpStartNode = getNode(tmpEdgeStartNode.node.id)
           if (tmpStartNode == null) {
             return null
           }
@@ -270,7 +315,7 @@ const ComponentsSideList = () => {
           const startPointPos = getPointPos(
             "out",
             tmpStartNode,
-            tmpEdgeStartNodeId.pointId,
+            tmpEdgeStartNode.pointId,
           )
           return (
             <div className="absolute top-0 left-0 h-full w-full" key="temp">
@@ -286,17 +331,49 @@ const ComponentsSideList = () => {
             </div>
           )
         })()}
-      {edges.map((edge) => (
-        <Line
-          key={`${edge.start.nodeId}_${edge.start.pointId}_${edge.end.nodeId}_${edge.end.pointId}`}
-          edge={edge}
-          getNode={getNode}
-          onDelete={() => {
-            console.log("onDelete")
-            setEdges((edges) => edges.filter((e) => !isSameEdge(e, edge)))
-          }}
-        />
-      ))}
+      {edges.map((edge) => {
+        const startNode = getNode(edge.start.nodeId)
+        const endNode = getNode(edge.end.nodeId)
+        if (startNode == null || endNode == null) {
+          return
+        }
+        return (
+          <Line
+            key={calcEdgeId(edge)}
+            start={{
+              node: startNode,
+              pointId: edge.start.pointId,
+            }}
+            end={{
+              node: endNode,
+              pointId: edge.end.pointId,
+            }}
+            isFocused={
+              focusItemId?.type === "edge" &&
+              focusItemId.start.nodeId === edge.start.nodeId &&
+              focusItemId.start.pointId === edge.start.pointId &&
+              focusItemId.end.nodeId === edge.end.nodeId &&
+              focusItemId.end.pointId === edge.end.pointId
+            }
+            onFocus={() =>
+              setFocusItemId({
+                type: "edge",
+                start: {
+                  nodeId: edge.start.nodeId,
+                  pointId: edge.start.pointId,
+                },
+                end: {
+                  nodeId: edge.end.nodeId,
+                  pointId: edge.end.pointId,
+                },
+              })
+            }
+            onDelete={() =>
+              setEdges((edges) => edges.filter((e) => !isSameEdge(e, edge)))
+            }
+          />
+        )
+      })}
 
       {nodes.map((node) => (
         <Draggable
@@ -304,6 +381,7 @@ const ComponentsSideList = () => {
           position={node.pos}
           bounds=".draggable-parent"
           defaultClassName="!absolute top-0 left-0"
+          defaultClassNameDragging="group"
           //dataはカーソルの位置が入る？
           onDrag={(_, data) =>
             setNodes((nodes) =>
@@ -319,110 +397,121 @@ const ComponentsSideList = () => {
           }
           onStart={() => regenerateNode(node)}
         >
-          {/* <> */}
-          {/* nodeの大枠を決める */}
-          <div
-            className="relative flex h-20 w-40 items-center justify-center rounded text-white shadow"
-            style={{ background: node.node.color }}
-          >
-            {/* nodeの名前 */}
-            {/* {node.node.label} */}
-            {checkNodeType(node)}
-            {/* ここに機能を追加する */}
-            {/* inPointsの描画 */}
+          <div>
             {/* <> */}
-            {/* {checkNodeType(node.node.nodeType)} */}
-            {/* 位置 */}
-            <div className="absolute inset-x-0 top-0 flex -translate-y-1/2 justify-evenly">
-              {/* 機能 */}
-              {node.inPoints.map((point, i) => (
-                <button
-                  key={i}
-                  className="relative"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    if (tmpEdgeStartNodeId == null) return
-                    const tmpEdgeStartNode = getNode(tmpEdgeStartNodeId.nodeId)
-                    if (tmpEdgeStartNode == null) return
+            {/* nodeの大枠を決める */}
+            <div
+              className={classNames(
+                "relative flex h-20 w-40 items-center justify-center rounded text-white shadow transition",
+                focusItemId?.type === "node" &&
+                  focusItemId.nodeId === node.id &&
+                  "ring-4 ring-blue-400 group-hover:shadow-2xl group-hover:ring-0",
+              )}
+              style={{ background: node.node.color }}
+              onClick={() =>
+                setFocusItemId({
+                  type: "node",
+                  nodeId: node.id,
+                })
+              }
+            >
+              {/* nodeの名前 */}
+              {/* {node.node.label} */}
+              {checkNodeType(node)}
+              {/* ここに機能を追加する */}
+              {/* inPointsの描画 */}
+              {/* <> */}
+              {/* {checkNodeType(node.node.nodeType)} */}
+              {/* 位置 */}
+              <div className="absolute inset-x-0 top-0 flex -translate-y-1/2 justify-evenly">
+                {/* 機能 */}
+                {node.inPoints.map((point, i) => {
+                  const isConnectableWithTempNode =
+                    tmpEdgeStartNode != null &&
+                    node.canConnect(
+                      i,
+                      tmpEdgeStartNode.node,
+                      tmpEdgeStartNode.pointId,
+                    )
 
-                    if (
-                      node.canConnect(
-                        i,
-                        tmpEdgeStartNode,
-                        tmpEdgeStartNodeId.pointId,
-                      )
-                    ) {
-                      setEdges((prev) => [
-                        ...prev,
-                        {
-                          start: tmpEdgeStartNodeId,
+                  return (
+                    <button
+                      key={i}
+                      className="relative"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        if (!isConnectableWithTempNode) {
+                          return
+                        }
+                        const edge = {
+                          start: {
+                            nodeId: tmpEdgeStartNode.node.id,
+                            pointId: tmpEdgeStartNode.pointId,
+                          },
                           end: {
                             nodeId: node.id,
                             pointId: i,
                           },
-                        },
-                      ])
-                      setTempEdgeStartNodeId(null)
-                    }
-                  }}
-                >
-                  {/* inputを選択しているときに，つなげられる可能性のある点の色分け */}
-                  <div
-                    className={classNames(
-                      "h-5 w-5 rounded-full border-2 border-white transition",
-                      tmpEdgeStartNodeId == null
-                        ? "border-white bg-green-500 hover:scale-110"
-                        : tmpEdgeStartNodeId != null &&
-                          node.canConnect(
-                            i,
-                            // @ts-ignore
-                            getNode(tmpEdgeStartNodeId.nodeId),
-                            tmpEdgeStartNodeId.pointId,
-                          )
-                        ? "scale-100 border-white bg-green-500 hover:scale-110"
-                        : "scale-50 cursor-not-allowed border-gray-100 bg-gray-300",
-                    )}
-                  />
-                  {/* inputの文字 */}
-                  <div className="absolute top-full left-1/2 -translate-x-1/2 text-sm leading-none text-white">
-                    {point.label}
-                  </div>
-                </button>
-              ))}
-            </div>
-            {/* outPointsの描画 */}
-            <div className="absolute inset-x-0 bottom-0 flex translate-y-1/2 justify-evenly">
-              {node.outPoints.map((point, i) => (
-                <button
-                  key={i}
-                  className="relative"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    if (tmpEdgeStartNodeId == null) {
+                        }
+                        setEdges((prev) => [...prev, edge])
+                        setTempEdgeStartNodeId(null)
+                      }}
+                    >
+                      {/* inputを選択しているときに，つなげられる可能性のある点の色分け */}
+                      <div
+                        className={classNames(
+                          "h-5 w-5 rounded-full border-2 border-white transition",
+                          tmpEdgeStartNodeId == null
+                            ? "border-white bg-green-500 hover:scale-110"
+                            : isConnectableWithTempNode
+                            ? "scale-100 border-white bg-green-500 hover:scale-110"
+                            : "scale-50 cursor-not-allowed border-gray-100 bg-gray-300",
+                        )}
+                      />
+                      {/* inputの文字 */}
+                      <div className="absolute top-full left-1/2 -translate-x-1/2 text-sm leading-none text-white">
+                        {point.label}
+                      </div>
+                    </button>
+                  )
+                })}
+              </div>
+              {/* outPointsの描画 */}
+              <div className="absolute inset-x-0 bottom-0 flex translate-y-1/2 justify-evenly">
+                {node.outPoints.map((point, i) => (
+                  <button
+                    key={i}
+                    className="relative"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      if (tmpEdgeStartNode != null) {
+                        return
+                      }
+                      setFocusItemId(null)
                       setTempEdgeStartNodeId({ nodeId: node.id, pointId: i })
-                    }
-                  }}
-                >
-                  {/* inPointsを選択中に，outPointsの色を変更する */}
-                  <div
-                    className={classNames(
-                      "h-5 w-5 rounded-full border-2 border-white transition",
-                      tmpEdgeStartNodeId == null
-                        ? "bg-yellow-500 hover:scale-110"
-                        : "scale-50 cursor-not-allowed bg-gray-300",
-                    )}
-                  />
-                  {/* outputの文字 */}
-                  <div className="absolute bottom-full left-1/2 -translate-x-1/2 text-sm leading-none text-white">
-                    {point.label}
-                  </div>
-                </button>
-              ))}
+                    }}
+                  >
+                    {/* inPointsを選択中に，outPointsの色を変更する */}
+                    <div
+                      className={classNames(
+                        "h-5 w-5 rounded-full border-2 border-white transition",
+                        tmpEdgeStartNodeId == null
+                          ? "bg-yellow-500 hover:scale-110"
+                          : "scale-50 cursor-not-allowed bg-gray-300",
+                      )}
+                    />
+                    {/* outputの文字 */}
+                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 text-sm leading-none text-white">
+                      {point.label}
+                    </div>
+                  </button>
+                ))}
+              </div>
+              {/* </> */}
             </div>
+            {/* {checkNodeType(node.node.nodeType)} */}
             {/* </> */}
           </div>
-          {/* {checkNodeType(node.node.nodeType)} */}
-          {/* </> */}
         </Draggable>
       ))}
     </div>

--- a/src/components/editor/helper.ts
+++ b/src/components/editor/helper.ts
@@ -17,3 +17,6 @@ export const isSameEdge = (e1: Edge, e2: Edge) => {
     e1.end.pointId === e2.end.pointId
   )
 }
+
+export const calcEdgeId = (edge: Edge) =>
+  `${edge.start.nodeId}_${edge.start.pointId}_${edge.end.nodeId}_${edge.end.pointId}`

--- a/src/components/presentation/LineUI.tsx
+++ b/src/components/presentation/LineUI.tsx
@@ -1,62 +1,87 @@
 import classNames from "classnames"
-import React, { useEffect, useState } from "react"
+import React, { useCallback, useEffect } from "react"
+import { FiTrash2 } from "react-icons/fi"
 
 export type LineUIProps = {
   startPos: { x: number; y: number }
   delta: { x: number; y: number }
+  isFocused?: boolean
+  onFocus?: () => void
   onDelete?: () => void
 }
 
-const LineUI: React.FC<LineUIProps> = ({ startPos, delta, onDelete }) => {
-  const [isFocused, setIsFocused] = useState(false)
-  // const [isFocused2, setIsFocused2] = useState(false)
-
+const LineUI: React.FC<LineUIProps> = ({
+  startPos,
+  delta,
+  isFocused = false,
+  onFocus,
+  onDelete,
+}) => {
   useEffect(() => {
-    const listener = () => setIsFocused(false)
-    window.addEventListener("click", listener)
-    return () => window.removeEventListener("click", listener)
-  }, []) //初回のみ実行
-
-  useEffect(() => {
-    const listener = () => {
-      // if (e.key === "Backspace" && e.ctrlKey === true && isFocused) {
-      console.log("onDelete@LineUI")
-      onDelete?.()
-      // }
+    const listener = (e: KeyboardEvent) => {
+      if (e.key === "Backspace" && e.ctrlKey === true && isFocused) {
+        console.log("onDelete@LineUI")
+        onDelete?.()
+      }
     }
     window.addEventListener("keydown", listener)
-    return () => {
-      window.removeEventListener("keydown", listener)
-    }
-  }, []) //初回のみ実行
+    return () => window.removeEventListener("keydown", listener)
+  }, [isFocused, onDelete]) //初回のみ実行
+
+  const path = `M ${startPos.x},${startPos.y} Q ${startPos.x} ${
+    startPos.y + delta.y / 4
+  } ${startPos.x + delta.x / 2},${startPos.y + delta.y / 2} T ${
+    startPos.x + delta.x
+  } ${startPos.y + delta.y}`
 
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      className="pointer-events-none overflow-visible"
-    >
-      <path
-        d={`M ${startPos.x},${startPos.y} Q ${startPos.x} ${
-          startPos.y + delta.y / 4
-        } ${startPos.x + delta.x / 2},${startPos.y + delta.y / 2} T ${
-          startPos.x + delta.x
-        } ${startPos.y + delta.y}`}
-        fill="none"
-        stroke="black"
+    <>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="pointer-events-none overflow-visible"
+      >
+        {/* NOTE: クリック領域を拡大するために、透明な太い線を設定 */}
+        <path
+          d={path}
+          fill="none"
+          stroke="transparent"
+          strokeWidth={20}
+          className="pointer-events-auto cursor-pointer"
+          onClick={onFocus}
+        />
+        <path
+          d={path}
+          fill="none"
+          stroke="black"
+          className={classNames(
+            "pointer-events-none transition-[stroke,stroke-width]",
+            isFocused
+              ? "stroke-red-400 stroke-[6px] drop-shadow-2xl"
+              : "stroke-gray-500 stroke-[4px]",
+          )}
+        />
+      </svg>
+      <div
         className={classNames(
-          "pointer-events-auto cursor-pointer transition",
-          isFocused
-            ? "stroke-red-600 stroke-[6px]"
-            : "stroke-gray-500 stroke-[4px]",
+          "absolute -translate-x-1/2 -translate-y-1/2",
+          !isFocused && "invisible",
         )}
-        onClick={(e) => {
-          e.stopPropagation()
-          setIsFocused(true)
-          // isFocused2 ? setIsFocused2(false) : setIsFocused2(true)
-          // console.log(isFocused2)
+        style={{
+          top: startPos.y + delta.y / 2,
+          left: startPos.x + delta.x / 2,
         }}
-      />
-    </svg>
+      >
+        <button
+          className="group group flex items-center justify-center rounded-full border-[3px] border-red-400 bg-red-400 p-1.5 text-white transition-[background-color,border-color] hover:bg-white hover:text-red-400"
+          onClick={onDelete}
+        >
+          <FiTrash2
+            size="18px"
+            className="transition group-hover:scale-110 group-hover:stroke-[2px]"
+          />
+        </button>
+      </div>
+    </>
   )
 }
 

--- a/src/components/utils/getCursorPos.ts
+++ b/src/components/utils/getCursorPos.ts
@@ -7,12 +7,10 @@ const useCursorPos = (keepUpdate: boolean) => {
 
   useEffect(() => {
     const listener = throttle(10, (e: MouseEvent) => {
-      if (keepUpdate) {
-        setPos({
-          x: e.clientX,
-          y: e.clientY,
-        })
-      }
+      setPos({
+        x: e.clientX,
+        y: e.clientY,
+      })
     })
 
     window.addEventListener("pointermove", listener)

--- a/src/pages/bot/[botId].tsx
+++ b/src/pages/bot/[botId].tsx
@@ -1,11 +1,10 @@
 import { NextPage } from "next"
-import React from "react"
 import ComponentsSideList from "../../components/componetsSideList"
 
 const BotEdit: NextPage = () => {
   return (
     <div>
-      <ComponentsSideList></ComponentsSideList>
+      <ComponentsSideList />
     </div>
   )
 }


### PR DESCRIPTION
- 従来実装ではエッジの削除がうまくいかなかったため、状態の持ち方を変更して実装した
- エッジのクリック領域を拡大した
- Lineコンポーネントのpropsの受け取り方を変更
- componentsSideListを、プログラムの流れが変わらない範囲で修正

<img width="455" alt="image" src="https://user-images.githubusercontent.com/38308823/179349996-1ab596a6-06f6-4141-81b9-47fcf0f12b7a.png">
